### PR TITLE
Support passing envp

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Small `execv/execve` wrapper
 ```ruby
 MRuby::Build.new do |conf|
 
-    # ... (snip) ...
+  # ... (snip) ...
 
-    conf.gem :github => 'haconiwa/mruby-exec'
+  conf.gem :github => 'haconiwa/mruby-exec'
 end
 ```
 
@@ -23,6 +23,14 @@ Exec.execv("/bin/bash")
 
 # Also you can pass more than 1 params
 Exec.execv("/bin/bash", "-l", "-c", "echo Hello exec")
+```
+
+```ruby
+Exec.execve({"FOO" => "bar"}, "/bin/bash", "-l")
+
+# ... or
+# env cleanup
+Exec.execve({}, "/bin/bash", "-l")
 ```
 
 ## License

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 MRUBY_CONFIG=File.expand_path(ENV["MRUBY_CONFIG"] || ".travis-build_config.rb")
-MRUBY_VERSION=ENV["MRUBY_VERSION"] || "1.2.0"
+MRUBY_VERSION=ENV["MRUBY_VERSION"] || "master"
 
 file :mruby do
   cmd =  "git clone --depth=1 git://github.com/mruby/mruby.git"

--- a/src/mrb_exec.c
+++ b/src/mrb_exec.c
@@ -6,6 +6,8 @@
 ** See Copyright Notice in LICENSE
 */
 
+#define _GNU_SOURCE
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -15,6 +17,7 @@
 #include <mruby/data.h>
 #include <mruby/string.h>
 #include <mruby/array.h>
+#include <mruby/hash.h>
 #include <mruby/error.h>
 #include "mrb_exec.h"
 
@@ -76,6 +79,47 @@ static mrb_value mrb_exec_do_exec(mrb_state *mrb, mrb_value self)
   return mrb_nil_value();
 }
 
+static mrb_value mrb_exec_do_execve(mrb_state *mrb, mrb_value self)
+{
+  mrb_value mrb_env;
+  mrb_value *mrb_argv;
+  mrb_int len, env_len;
+  char **result, **envp;
+  int i;
+
+  mrb_get_args(mrb, "H*", &mrb_env, &mrb_argv, &len);
+  result = (char **)mrb_malloc(mrb, sizeof(char *) * (len + 1));
+
+  if(mrb_value_to_strv(mrb, mrb_argv, len, result) < 0){
+    mrb_sys_fail(mrb, "[BUG] mrb_value_to_strv failed");
+  }
+
+  int ai = mrb_gc_arena_save(mrb);
+  mrb_value keys = mrb_hash_keys(mrb, mrb_env);
+  env_len = RARRAY_LEN(keys);
+  envp = (char **)mrb_malloc(mrb, sizeof(char *) * (env_len + 1));
+
+  for (i = 0; i < env_len; ++i) {
+    mrb_value key = mrb_ary_ref(mrb, keys, i);
+    mrb_value value = mrb_hash_get(mrb, mrb_env, key);
+    mrb_value strv = mrb_convert_type(mrb, value, MRB_TT_STRING, "String", "to_str");
+    asprintf(envp, "%s=%s", mrb_string_value_cstr(mrb, &key), mrb_string_value_cstr(mrb, &strv));
+    envp++;
+  }
+  *envp = NULL;
+  envp -= i;
+  mrb_gc_arena_restore(mrb, ai);
+
+  for(int j = 0; j < env_len + 1; j++) {
+    _DEBUGP("[mruby-exec] envp(%i): %s\n", j, envp[j]);
+  }
+
+  execve(result[0], result, envp);
+
+  mrb_sys_fail(mrb, "execve failed");
+  return mrb_nil_value();
+}
+
 static mrb_value mrb_exec_exec_override_procname(mrb_state *mrb, mrb_value self)
 {
   mrb_value *argv;
@@ -106,6 +150,8 @@ void mrb_mruby_exec_gem_init(mrb_state *mrb)
   mrb_define_class_method(mrb, ex, "exec", mrb_exec_do_exec, MRB_ARGS_ANY());
   mrb_define_class_method(mrb, ex, "execv", mrb_exec_do_exec, MRB_ARGS_ANY());
   mrb_define_class_method(mrb, ex, "exec_override_procname", mrb_exec_exec_override_procname, MRB_ARGS_ANY());
+
+  mrb_define_class_method(mrb, ex, "execve", mrb_exec_do_execve, MRB_ARGS_ANY());
 
   mrb_define_method(mrb, mrb->kernel_module, "exec", mrb_exec_do_exec, MRB_ARGS_ANY());
   DONE;

--- a/src/mrb_exec.c
+++ b/src/mrb_exec.c
@@ -100,15 +100,15 @@ static mrb_value mrb_exec_exec_override_procname(mrb_state *mrb, mrb_value self)
 
 void mrb_mruby_exec_gem_init(mrb_state *mrb)
 {
-    struct RClass *ex;
+  struct RClass *ex;
 
-    ex = mrb_define_module(mrb, "Exec");
-    mrb_define_class_method(mrb, ex, "exec", mrb_exec_do_exec, MRB_ARGS_ANY());
-    mrb_define_class_method(mrb, ex, "execv", mrb_exec_do_exec, MRB_ARGS_ANY());
-    mrb_define_class_method(mrb, ex, "exec_override_procname", mrb_exec_exec_override_procname, MRB_ARGS_ANY());
+  ex = mrb_define_module(mrb, "Exec");
+  mrb_define_class_method(mrb, ex, "exec", mrb_exec_do_exec, MRB_ARGS_ANY());
+  mrb_define_class_method(mrb, ex, "execv", mrb_exec_do_exec, MRB_ARGS_ANY());
+  mrb_define_class_method(mrb, ex, "exec_override_procname", mrb_exec_exec_override_procname, MRB_ARGS_ANY());
 
-    mrb_define_method(mrb, mrb->kernel_module, "exec", mrb_exec_do_exec, MRB_ARGS_ANY());
-    DONE;
+  mrb_define_method(mrb, mrb->kernel_module, "exec", mrb_exec_do_exec, MRB_ARGS_ANY());
+  DONE;
 }
 
 void mrb_mruby_exec_gem_final(mrb_state *mrb)

--- a/src/mrb_exec.c
+++ b/src/mrb_exec.c
@@ -11,11 +11,11 @@
 #include <string.h>
 #include <unistd.h>
 
-#include "mruby.h"
-#include "mruby/data.h"
-#include "mruby/string.h"
-#include "mruby/array.h"
-#include "mruby/error.h"
+#include <mruby.h>
+#include <mruby/data.h>
+#include <mruby/string.h>
+#include <mruby/array.h>
+#include <mruby/error.h>
 #include "mrb_exec.h"
 
 #define DONE mrb_gc_arena_restore(mrb, 0);
@@ -25,14 +25,6 @@
 #else
 #define _DEBUGP 1 ? (void) 0 : printf
 #endif
-
-typedef struct {
-  char *dummy;
-} mrb_exec_data;
-
-static const struct mrb_data_type mrb_exec_data_type = {
-  "mrb_exec_data", mrb_free,
-};
 
 static mrb_value mrb_exec_do_exec(mrb_state *mrb, mrb_value self)
 {

--- a/src/mrb_exec.c
+++ b/src/mrb_exec.c
@@ -78,44 +78,21 @@ static mrb_value mrb_exec_do_exec(mrb_state *mrb, mrb_value self)
 
 static mrb_value mrb_exec_exec_override_procname(mrb_state *mrb, mrb_value self)
 {
-  mrb_value argv;
-  int argc;
+  mrb_value *argv;
+  mrb_int len;
   char *procname, *execname;
-  char **argv_;
-  mrb_value strv;
-  char *buf;
-  int i, j, ai;
+  char **result;
 
-  mrb_get_args(mrb, "zA", &procname, &argv);
-  argc = RARRAY_LEN( argv );
-  if(argc < 1) {
-    mrb_raise(mrb, E_ARGUMENT_ERROR, "exec must have at least 1 argument");
-    return mrb_nil_value();
+  mrb_get_args(mrb, "z*", &procname, &argv, &len);
+  result = (char **)mrb_malloc(mrb, sizeof(char *) * (len + 1));
+
+  if(mrb_value_to_strv(mrb, argv, len, result) < 0){
+    mrb_sys_fail(mrb, "[BUG] mrb_value_to_strv failed");
   }
 
-  argv_ = (char **)mrb_malloc(mrb, sizeof(char *) * (argc + 1));
-
-  ai = mrb_gc_arena_save(mrb);
-  for(i = 0; i < argc; i++) {
-    strv = mrb_convert_type(mrb, mrb_ary_ref( mrb, argv, i ), MRB_TT_STRING, "String", "to_str");
-    buf = (char *)mrb_string_value_cstr(mrb, &strv);
-    *argv_ = buf;
-    argv_++;
-  }
-  *argv_ = NULL;
-
-  // return to the top of array
-  argv_ -= i;
-
-  for(j = 0; j < argc + 1; j++) {
-    _DEBUGP("[mruby-exec] argv_(%i): %s\n", j, argv_[j]);
-  }
-
-  mrb_gc_arena_restore(mrb, ai);
-
-  execname = strdup(argv_[0]);
-  argv_[0] = procname;
-  execv(execname, argv_);
+  execname = strdup(result[0]);
+  result[0] = procname;
+  execv(execname, result);
 
   mrb_sys_fail(mrb, "execv failed");
   return mrb_nil_value();
@@ -128,7 +105,7 @@ void mrb_mruby_exec_gem_init(mrb_state *mrb)
     ex = mrb_define_module(mrb, "Exec");
     mrb_define_class_method(mrb, ex, "exec", mrb_exec_do_exec, MRB_ARGS_ANY());
     mrb_define_class_method(mrb, ex, "execv", mrb_exec_do_exec, MRB_ARGS_ANY());
-    mrb_define_class_method(mrb, ex, "exec_override_procname", mrb_exec_exec_override_procname, MRB_ARGS_REQ(2));
+    mrb_define_class_method(mrb, ex, "exec_override_procname", mrb_exec_exec_override_procname, MRB_ARGS_ANY());
 
     mrb_define_method(mrb, mrb->kernel_module, "exec", mrb_exec_do_exec, MRB_ARGS_ANY());
     DONE;


### PR DESCRIPTION
```ruby
Exec.execve({"FOO" => "bar"}, "/bin/bash", "-l")

# ... or
# env cleanup
Exec.execve({}, "/bin/bash", "-l")
```

With some refactors.