### PR TITLE
Fixes on C99 compile errors (c99でのコンパイルエラーの修正)

### DIFF
--- a/src/mrb_exec.c
+++ b/src/mrb_exec.c
@@ -61,7 +61,7 @@ static int mrb_value_to_strv(mrb_state *mrb, mrb_value *array, mrb_int len, char
 {
   mrb_value strv;
   char *buf;
-  int i;
+  int i, j;
 
   if (len < 1) {
     mrb_raise(mrb, E_ARGUMENT_ERROR, "must have at least 1 argument");
@@ -79,7 +79,7 @@ static int mrb_value_to_strv(mrb_state *mrb, mrb_value *array, mrb_int len, char
   // return to the top of array
   result -= i;
 
-  for (int j = 0; j < len + 1; j++) {
+  for (j = 0; j < len + 1; j++) {
     _DEBUGP("[mruby-exec] result(%i): %s\n", j, result[j]);
   }
 

--- a/src/mrb_exec.c
+++ b/src/mrb_exec.c
@@ -113,7 +113,7 @@ static mrb_value mrb_exec_do_execve(mrb_state *mrb, mrb_value self)
   mrb_value *mrb_argv;
   mrb_int len, env_len;
   char **result, **envp;
-  int i;
+  int i, j;
 
   mrb_get_args(mrb, "H*", &mrb_env, &mrb_argv, &len);
   result = (char **)mrb_malloc(mrb, sizeof(char *) * (len + 1));
@@ -138,7 +138,7 @@ static mrb_value mrb_exec_do_execve(mrb_state *mrb, mrb_value self)
   envp -= i;
   mrb_gc_arena_restore(mrb, ai);
 
-  for (int j = 0; j < env_len + 1; j++) {
+  for (j = 0; j < env_len + 1; j++) {
     _DEBUGP("[mruby-exec] envp(%i): %s\n", j, envp[j]);
   }
 


### PR DESCRIPTION
FreeBSD/GCC4.2でのコンパイルでエラーが出てたので修正しました。

----

There occurred compilation errors on FreeBSD/GCC4.2, so I fixed. (Translation by @udzura)