### PR TITLE
Should use mrb_sys_fail when system call failed

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -4,4 +4,5 @@ MRuby::Gem::Specification.new('mruby-exec') do |spec|
 
   spec.add_test_dependency('mruby-process', :github => 'iij/mruby-process')
   spec.add_test_dependency('mruby-io', :github => 'iij/mruby-io')
+  spec.add_test_dependency('mruby-errno', :github => 'iij/mruby-errno')
 end

--- a/src/mrb_exec.c
+++ b/src/mrb_exec.c
@@ -35,28 +35,6 @@
 
 #define SYS_FAIL_MESSAGE_LENGTH 2048
 
-static void mrb_exec_sys_fail(mrb_state *mrb, int error_no, const char *fmt, ...)
-{
-  char buf[1024];
-  char arg_msg[SYS_FAIL_MESSAGE_LENGTH];
-  char err_msg[SYS_FAIL_MESSAGE_LENGTH];
-  char *ret;
-  va_list args;
-
-  va_start(args, fmt);
-  vsnprintf(arg_msg, SYS_FAIL_MESSAGE_LENGTH, fmt, args);
-  va_end(args);
-
-  if ((ret = strerror_r(error_no, buf, 1024)) == NULL) {
-    snprintf(err_msg, SYS_FAIL_MESSAGE_LENGTH, "[BUG] strerror_r failed. errno: %d message: %s", errno, arg_msg);
-    mrb_sys_fail(mrb, err_msg);
-  }
-
-  snprintf(err_msg, SYS_FAIL_MESSAGE_LENGTH, "sys failed. errno: %d message: %s mrbgem message: %s", error_no, ret,
-           arg_msg);
-  mrb_sys_fail(mrb, err_msg);
-}
-
 static int mrb_value_to_strv(mrb_state *mrb, mrb_value *array, mrb_int len, char **result)
 {
   mrb_value strv;
@@ -104,7 +82,7 @@ static mrb_value mrb_exec_do_exec(mrb_state *mrb, mrb_value self)
   execv(result[0], result);
 
   mrb_free(mrb, result);
-  mrb_exec_sys_fail(mrb, errno, "execv failed");
+  mrb_sys_fail(mrb, "execv failed");
 
   return mrb_nil_value();
 }
@@ -146,7 +124,7 @@ static mrb_value mrb_exec_do_execve(mrb_state *mrb, mrb_value self)
 
   execve(result[0], result, envp);
 
-  mrb_exec_sys_fail(mrb, errno, "execve failed");
+  mrb_sys_fail(mrb, "execve failed");
 
   return mrb_nil_value();
 }
@@ -169,7 +147,7 @@ static mrb_value mrb_exec_exec_override_procname(mrb_state *mrb, mrb_value self)
   result[0] = procname;
   execv(execname, result);
 
-  mrb_exec_sys_fail(mrb, errno, "execv failed");
+  mrb_sys_fail(mrb, "execv failed");
 
   return mrb_nil_value();
 }

--- a/test/mrb_exec.rb
+++ b/test/mrb_exec.rb
@@ -30,7 +30,7 @@ assert("Kernel#exec") do
 end
 
 assert("Kernel#exec sys fail") do
-  expected_error_message = "sys failed. errno: 2 message: No such file or directory mrbgem message: execv failed"
+  expected_error_message = "No such file or directory - execv failed"
 
   begin
     # always failed


### PR DESCRIPTION
The following warning occurred on darwin.

And failed testing.

```
$ rake test
cd mruby && MRUBY_CONFIG=/Users/ksss/src/github.com/ksss/mruby-exec/.travis-build_config.rb rake all test
CC    ../src/mrb_exec.c -> build/host/mrbgems/mruby-exec/src/mrb_exec.o
/Users/ksss/src/github.com/ksss/mruby-exec/src/mrb_exec.c:50:12: warning: incompatible integer to pointer conversion assigning to 'char *' from 'int'
      [-Wint-conversion]
  if ((ret = strerror_r(error_no, buf, 1024)) == NULL) {
           ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
AR    build/host/lib/libmruby.a
GEN   *.rb -> build/host/mrbgems/mruby-test/mrbtest.c
CC    build/host/mrbgems/mruby-test/mrbtest.c -> build/host/mrbgems/mruby-test/mrbtest.o
LD    build/host/bin/mrbtest
LD    build/host/bin/mirb
LD    build/host/bin/mruby
LD    build/host/bin/mruby-strip

Build summary:

================================================
      Config Name: host
 Output Directory: build/host
         Binaries: mrbc, mrbtest
    Included Gems:
             mruby-io - IO and File class
             mruby-pack - Array#pack and String#unpack method
             mruby-sprintf - standard Kernel#sprintf method
             mruby-print - standard print/puts/p
             mruby-math - standard Math module
             mruby-time - standard Time class
             mruby-struct - standard Struct class
             mruby-compar-ext - Enumerable module extension
             mruby-enum-ext - Enumerable module extension
             mruby-fiber - Fiber class
             mruby-enumerator - Enumerator class
             mruby-string-ext - String class extension
             mruby-numeric-ext - Numeric class extension
             mruby-array-ext - Array class extension
             mruby-hash-ext - Hash class extension
             mruby-range-ext - Range class extension
             mruby-proc-ext - Proc class extension
             mruby-symbol-ext - Symbol class extension
             mruby-random - Random class
             mruby-object-ext - Object class extension
             mruby-objectspace - ObjectSpace class
             mruby-enum-lazy - Enumerator::Lazy class
             mruby-toplevel-ext - toplevel object (main) methods extension
             mruby-compiler - mruby compiler library
             mruby-bin-mirb - mirb command
               - Binaries: mirb
             mruby-error - extensional error handling
             mruby-bin-mruby - mruby command
               - Binaries: mruby
             mruby-bin-strip - irep dump debug section remover command
               - Binaries: mruby-strip
             mruby-kernel-ext - Kernel module extension
             mruby-class-ext - class/module extension
             mruby-process
             mruby-exec
             mruby-bin-mrbc - mruby compiler executable
             mruby-test - mruby test
================================================

>>> Test host <<<
mrbtest - Embeddable Ruby Test

.........?.....?...........................................................................................................................................................................?......................................................................................................................................................................................................................................................................?........................F...................................................................................................................................................................................................................??.........................................................................................................................................................................................................................?..........................................................................................................................................................................................
Skip: File#mtime => File#mtime require Time (mrbgems: mruby-io)
Skip: File.expand_path (with ENV) =>  (mrbgems: mruby-io)
Skip: Struct.new removes existing constant => redefining Struct with same name cause warnings (mrbgems: mruby-struct)
Skip: Kernel.caller, Kernel#caller => backtrace isn't available (mrbgems: mruby-kernel-ext)
Fail: Kernel#exec sys fail (mrbgems: mruby-exec)
 - Assertion[1] Failed: Expected to be equal
    Expected: "sys failed. errno: 2 message: No such file or directory mrbgem message: execv failed"
      Actual: "[BUG] strerror_r failed. errno: 2 message: execv failed"
Skip: GC in rescue => backtrace isn't available (mrbgems: mruby-test)
Skip: Method call in rescue => backtrace isn't available (mrbgems: mruby-test)
Skip: Module#prepend super in alias => super does not currently work in aliased methods (mrbgems: mruby-test)
Total: 1086
   OK: 1085
   KO: 1
Crash: 0
 Time: 0.23 seconds
rake aborted!
Command failed with status (1): ["build/host/bin/mrbtest"...]
/Users/ksss/src/github.com/ksss/mruby-exec/mruby/lib/mruby/build.rb:299:in `run_test'
/Users/ksss/src/github.com/ksss/mruby-exec/mruby/Rakefile:123:in `block (2 levels) in <top (required)>'
/Users/ksss/src/github.com/ksss/mruby-exec/mruby/lib/mruby/build.rb:13:in `instance_eval'
/Users/ksss/src/github.com/ksss/mruby-exec/mruby/lib/mruby/build.rb:13:in `block in each_target'
/Users/ksss/src/github.com/ksss/mruby-exec/mruby/lib/mruby/build.rb:12:in `each'
/Users/ksss/src/github.com/ksss/mruby-exec/mruby/lib/mruby/build.rb:12:in `each_target'
/Users/ksss/src/github.com/ksss/mruby-exec/mruby/Rakefile:122:in `block in <top (required)>'
Tasks: TOP => test
(See full trace by running task with --trace)
rake aborted!
Command failed with status (1): [cd mruby && MRUBY_CONFIG=/Users/ksss/src/g...]
/Users/ksss/src/github.com/ksss/mruby-exec/Rakefile:20:in `block in <top (required)>'
Tasks: TOP => test
(See full trace by running task with --trace)
```

`strerror_r` is not portable because it have different spec on XSI or GNU

http://man7.org/linux/man-pages/man3/strerror.3.html

And I think, This process should delegate to `mrb_sys_fail`.